### PR TITLE
fix: resolve file handle leak and partial write cleanup in filesystem Put

### DIFF
--- a/internal/provider/storage/filesystem/filesystem.go
+++ b/internal/provider/storage/filesystem/filesystem.go
@@ -38,12 +38,19 @@ func (p *Provider) Put(_ context.Context, key string, reader io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", key, err)
 	}
-	defer f.Close()
 
 	if _, err := io.Copy(f, reader); err != nil {
+		f.Close()
+		os.Remove(path)
 		return fmt.Errorf("writing file %s: %w", key, err)
 	}
-	return f.Close()
+
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return fmt.Errorf("closing file %s: %w", key, err)
+	}
+
+	return nil
 }
 
 func (p *Provider) Get(_ context.Context, key string) (io.ReadCloser, error) {

--- a/internal/provider/storage/filesystem/filesystem_test.go
+++ b/internal/provider/storage/filesystem/filesystem_test.go
@@ -3,7 +3,10 @@ package filesystem
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -160,5 +163,79 @@ func TestRename(t *testing.T) {
 	got, _ := io.ReadAll(rc)
 	if !bytes.Equal(got, data) {
 		t.Errorf("renamed file content = %q, want %q", got, data)
+	}
+}
+
+// errReader is an io.Reader that returns an error after reading n bytes.
+type errReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if r.pos >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func TestPutWriteErrorCleansUpFile(t *testing.T) {
+	dir := t.TempDir()
+	p, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	readErr := errors.New("simulated read failure")
+	reader := &errReader{data: []byte("partial"), err: readErr}
+
+	err = p.Put(ctx, "sub/fail.txt", reader)
+	if err == nil {
+		t.Fatal("Put() should have returned an error")
+	}
+	if !errors.Is(err, readErr) {
+		t.Errorf("Put() error = %v, want wrapped %v", err, readErr)
+	}
+
+	// The partial file should have been cleaned up.
+	path := filepath.Join(dir, "sub", "fail.txt")
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("partial file %s was not cleaned up after write error", path)
+	}
+}
+
+func TestPutNoDoubleClose(t *testing.T) {
+	dir := t.TempDir()
+	p, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	data := []byte("test content for close check")
+	if err := p.Put(ctx, "close-test.txt", bytes.NewReader(data)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the file was written correctly (no double-close corruption).
+	rc, err := p.Get(ctx, "close-test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("Get() = %q, want %q", got, data)
 	}
 }


### PR DESCRIPTION
## Summary
- **Removed `defer f.Close()`** in `Put()` — the deferred close ran after an explicit `f.Close()`, causing a double-close and silently discarding the flush error on the deferred path
- **Added explicit `Close()` error checking** after a successful write, since `Close()` can fail when flushing OS buffers to disk
- **Partial files are now cleaned up** (`os.Remove`) on both write errors and close errors, preventing leftover corrupt files on disk
- **Added two new tests**: `TestPutWriteErrorCleansUpFile` (verifies partial file removal on read error) and `TestPutNoDoubleClose` (verifies correct write without double-close corruption)

Fixes #2

## Test plan
- [x] All existing filesystem provider tests pass (`go test ./internal/provider/storage/filesystem/ -v`)
- [x] New `TestPutWriteErrorCleansUpFile` confirms partial files are removed on write failure
- [x] New `TestPutNoDoubleClose` confirms successful writes produce correct file content
- [x] Full unit test suite passes (`go test ./...`)
- [x] `go vet ./...` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)