### PR TITLE
feat(config): add connection pool configuration for database providers

### DIFF
--- a/cmd/apr/main.go
+++ b/cmd/apr/main.go
@@ -74,9 +74,9 @@ func makeDBProvider(src config.SourceConfig) (database.Provider, error) {
 	user, pass := resolveCredentials(src.Credentials)
 	switch src.Engine {
 	case "postgres":
-		return dbpg.New(src.Host, src.Port, src.Database, user, pass, src.SSLMode), nil
+		return dbpg.New(src.Host, src.Port, src.Database, user, pass, src.SSLMode, src.Pool), nil
 	case "mysql":
-		return dbmysql.New(src.Host, src.Port, src.Database, user, pass), nil
+		return dbmysql.New(src.Host, src.Port, src.Database, user, pass, src.Pool), nil
 	default:
 		return nil, fmt.Errorf("unsupported engine: %s", src.Engine)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -196,7 +196,7 @@ func TestPostgresArchiveAndRestore(t *testing.T) {
 	ctx := context.Background()
 
 	// Connect via provider.
-	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable")
+	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable", config.PoolConfig{})
 	if err := pgProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting postgres provider: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestPostgresCompositePK(t *testing.T) {
 	resetPostgres(t)
 	ctx := context.Background()
 
-	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable")
+	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable", config.PoolConfig{})
 	if err := pgProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting postgres provider: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestMySQLArchiveAndRestore(t *testing.T) {
 	resetMySQL(t)
 	ctx := context.Background()
 
-	myProvider := mysql.New(myHost, myPort, myDB, myUser, myPass)
+	myProvider := mysql.New(myHost, myPort, myDB, myUser, myPass, config.PoolConfig{})
 	if err := myProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting mysql provider: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestMySQLCompositePK(t *testing.T) {
 	resetMySQL(t)
 	ctx := context.Background()
 
-	myProvider := mysql.New(myHost, myPort, myDB, myUser, myPass)
+	myProvider := mysql.New(myHost, myPort, myDB, myUser, myPass, config.PoolConfig{})
 	if err := myProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting mysql provider: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestArchiveIsIdempotent(t *testing.T) {
 	resetPostgres(t)
 	ctx := context.Background()
 
-	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable")
+	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable", config.PoolConfig{})
 	if err := pgProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting postgres provider: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestNullableRoundTrip(t *testing.T) {
 	resetPostgres(t)
 	ctx := context.Background()
 
-	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable")
+	pgProvider := postgres.New(pgHost, pgPort, pgDB, pgUser, pgPass, "disable", config.PoolConfig{})
 	if err := pgProvider.Connect(ctx); err != nil {
 		t.Fatalf("connecting postgres provider: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -66,6 +67,16 @@ type SourceConfig struct {
 	Database    string           `yaml:"database"`
 	Credentials CredentialConfig `yaml:"credentials"`
 	SSLMode     string           `yaml:"ssl_mode,omitempty"`
+	Pool        PoolConfig       `yaml:"pool,omitempty"`
+}
+
+// PoolConfig defines database connection pool settings.
+// Zero values mean the Go database/sql defaults are used.
+type PoolConfig struct {
+	MaxOpenConns    int           `yaml:"max_open_conns"`
+	MaxIdleConns    int           `yaml:"max_idle_conns"`
+	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime"`
+	ConnMaxIdleTime time.Duration `yaml:"conn_max_idle_time"`
 }
 
 // CredentialConfig defines how to obtain database credentials.

--- a/internal/provider/database/mysql/mysql.go
+++ b/internal/provider/database/mysql/mysql.go
@@ -7,21 +7,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/carlos-loya/archive-purge-restore/internal/config"
 	"github.com/carlos-loya/archive-purge-restore/internal/provider/database"
 	_ "github.com/go-sql-driver/mysql"
 )
 
 // Provider implements database.Provider for MySQL.
 type Provider struct {
-	dsn string
-	db  *sql.DB
+	dsn  string
+	pool config.PoolConfig
+	db   *sql.DB
 }
 
 // New creates a new MySQL provider.
-func New(host string, port int, dbname, user, password string) *Provider {
+func New(host string, port int, dbname, user, password string, pool config.PoolConfig) *Provider {
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true",
 		user, password, host, port, dbname)
-	return &Provider{dsn: dsn}
+	return &Provider{dsn: dsn, pool: pool}
 }
 
 // NewFromDSN creates a MySQL provider from a DSN string.
@@ -37,6 +39,18 @@ func (p *Provider) Connect(ctx context.Context) error {
 	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		return fmt.Errorf("pinging mysql: %w", err)
+	}
+	if p.pool.MaxOpenConns != 0 {
+		db.SetMaxOpenConns(p.pool.MaxOpenConns)
+	}
+	if p.pool.MaxIdleConns != 0 {
+		db.SetMaxIdleConns(p.pool.MaxIdleConns)
+	}
+	if p.pool.ConnMaxLifetime != 0 {
+		db.SetConnMaxLifetime(p.pool.ConnMaxLifetime)
+	}
+	if p.pool.ConnMaxIdleTime != 0 {
+		db.SetConnMaxIdleTime(p.pool.ConnMaxIdleTime)
 	}
 	p.db = db
 	return nil

--- a/internal/provider/database/postgres/postgres.go
+++ b/internal/provider/database/postgres/postgres.go
@@ -7,24 +7,26 @@ import (
 	"strings"
 	"time"
 
+	"github.com/carlos-loya/archive-purge-restore/internal/config"
 	"github.com/carlos-loya/archive-purge-restore/internal/provider/database"
 	_ "github.com/lib/pq"
 )
 
 // Provider implements database.Provider for PostgreSQL.
 type Provider struct {
-	dsn string
-	db  *sql.DB
+	dsn  string
+	pool config.PoolConfig
+	db   *sql.DB
 }
 
 // New creates a new PostgreSQL provider.
-func New(host string, port int, dbname, user, password, sslMode string) *Provider {
+func New(host string, port int, dbname, user, password, sslMode string, pool config.PoolConfig) *Provider {
 	if sslMode == "" {
 		sslMode = "prefer"
 	}
 	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
 		host, port, dbname, user, password, sslMode)
-	return &Provider{dsn: dsn}
+	return &Provider{dsn: dsn, pool: pool}
 }
 
 // NewFromDSN creates a PostgreSQL provider from a DSN string.
@@ -40,6 +42,18 @@ func (p *Provider) Connect(ctx context.Context) error {
 	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		return fmt.Errorf("pinging postgres: %w", err)
+	}
+	if p.pool.MaxOpenConns != 0 {
+		db.SetMaxOpenConns(p.pool.MaxOpenConns)
+	}
+	if p.pool.MaxIdleConns != 0 {
+		db.SetMaxIdleConns(p.pool.MaxIdleConns)
+	}
+	if p.pool.ConnMaxLifetime != 0 {
+		db.SetConnMaxLifetime(p.pool.ConnMaxLifetime)
+	}
+	if p.pool.ConnMaxIdleTime != 0 {
+		db.SetConnMaxIdleTime(p.pool.ConnMaxIdleTime)
 	}
 	p.db = db
 	return nil


### PR DESCRIPTION
## Summary
- Add `PoolConfig` struct with `max_open_conns`, `max_idle_conns`, `conn_max_lifetime`, and `conn_max_idle_time` fields to `SourceConfig` in the YAML config
- Apply pool settings in both PostgreSQL and MySQL provider `Connect()` methods (only when non-zero, preserving Go defaults)
- Wire pool config through `makeDBProvider` in `cmd/apr/main.go` and update integration test call sites

Fixes #9

## Test plan
- [x] All existing unit tests pass (`go test ./... -v`)
- [x] `go vet ./...` passes with no issues
- [x] Integration tests compile with updated `New()` signatures (verified via `go vet`, requires Docker to run)
- [ ] Manually verify pool settings by adding a `pool:` section to `apr.yaml` and confirming connections are bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)