### PR TITLE
fix: standardize error messages in validate command

### DIFF
--- a/cmd/apr/main.go
+++ b/cmd/apr/main.go
@@ -331,10 +331,10 @@ func validateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := loadConfig()
 			if err != nil {
-				return fmt.Errorf("config validation failed: %w", err)
+				return fmt.Errorf("loading config: %w", err)
 			}
 			if err := cfg.Validate(); err != nil {
-				return fmt.Errorf("config validation failed: %w", err)
+				return fmt.Errorf("invalid config: %w", err)
 			}
 			fmt.Println("Configuration is valid.")
 			fmt.Printf("  Storage: %s\n", cfg.Storage.Type)


### PR DESCRIPTION
## Summary
- Aligned `validateCmd` error messages with the pattern used by all other commands (`daemon`, `archive`, `restore`, `history`): `"loading config: %w"` for load failures and `"invalid config: %w"` for validation failures
- Performed full codebase audit confirming all `fmt.Errorf` calls already use `%w` for error wrapping (zero instances of `%v` misuse found)
- Verified all error messages are lowercase, have no trailing punctuation, and follow the `"context: %w"` convention

Fixes #10

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -v` passes (all unit tests green)
- [x] Searched all `.go` files for `fmt.Errorf.*%v` patterns -- zero instances found
- [x] Verified no capitalized error messages or messages ending with punctuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)