### PR TITLE
feat!: adopt metav1.Condition for resource status (#63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,14 +103,14 @@ internal/
     databaseconnection_controller.go     # validates referenced Secret exists with expected keys
     storagebackend_controller.go         # same, type-aware (filesystem needs none)
     archiverule_controller.go            # in-controller cron + Job spawn + failure tracking + history pruning
-    restorerequest_controller.go         # spawns one-shot Job, derives Phase from Job state
+    restorerequest_controller.go         # spawns one-shot Job, derives lifecycle conditions from Job state
     jobspec.go                           # buildJobEnv shared between archive CronJob and restore Job
     metrics_emit.go                      # emits archive/restore_runs_total when Job becomes terminal
 
   cluster/                               # K8s-aware glue between operator and engine — used by Job pods only
     client.go                            # NewClient: in-cluster or kubeconfig
     translate.go                         # CR → engine config (with env-var credential resolution)
-    sink.go                              # patches CR status from inside the Job pod (LastRunResult, etc.)
+    sink.go                              # patches CR status from inside the Job pod (rows, runID, Degraded condition)
     run.go                               # RunArchiveFromCR / RunRestoreFromCR orchestrators
 
   webhook/                               # Validating admission webhook handlers (controller-runtime CustomValidator[T])
@@ -199,8 +199,8 @@ batch-INSERT into the database.
 |---|---|---|
 | `DatabaseConnection` | engine, host, port, database, sslMode, credentialsSecretRef | Ready condition |
 | `StorageBackend` | type (s3/r2/gcs/filesystem), bucket, region, prefix, endpoint, accountID, credentialsSecretRef | Ready condition |
-| `ArchiveRule` | databaseRef, storageRef, table, dateColumn, daysOnline, schedule, batchSize, suspend, maxFailures, historyLimit | activeJobRef, lastJobRef, lastRunResult, lastRunRowsArchived, lastRunID, lastRunTime, nextScheduledTime, lastTriggerTime, consecutiveFailures, conditions |
-| `RestoreRequest` | archiveRuleRef, date, runID, table | phase, jobRef, rowsRestored, startTime, completionTime, conditions |
+| `ArchiveRule` | databaseRef, storageRef, table, dateColumn, daysOnline, schedule, batchSize, suspend, maxFailures, historyLimit | activeJobRef, lastJobRef, lastRunRowsArchived, lastRunID, lastRunTime, nextScheduledTime, lastTriggerTime, consecutiveFailures, conditions (Ready/ScheduleValid/Progressing/Degraded) |
+| `RestoreRequest` | archiveRuleRef, date, runID, table | jobRef, rowsRestored, startTime, completionTime, conditions (Ready/Progressing/Succeeded/Failed) |
 
 Annotation: `apr.dev/trigger-time` (RFC3339) on an ArchiveRule fires an
 immediate run on the next reconcile, deduplicated against

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ spec:
 
 ```text
 $ kubectl get archiverule orders-archive
-NAME             TABLE    SCHEDULE    DAYS-ONLINE   LAST-RESULT   ROWS-ARCHIVED   NEXT-RUN
-orders-archive   orders   0 2 * * *   90            Succeeded     14823           2026-05-09T02:00:00Z
+NAME             TABLE    SCHEDULE    DAYS-ONLINE   READY   PROGRESSING   DEGRADED   ROWS-ARCHIVED   NEXT-RUN
+orders-archive   orders   0 2 * * *   90            True    False         False      14823           2026-05-09T02:00:00Z
+
+$ kubectl wait archiverule/orders-archive --for=condition=Ready --timeout=60s
+archiverule.apr.dev/orders-archive condition met
 ```
 
 ## Why APR?

--- a/api/v1alpha1/archiverule_types.go
+++ b/api/v1alpha1/archiverule_types.go
@@ -8,16 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ArchiveRunResult is the terminal state of an archive run.
-// +kubebuilder:validation:Enum=Succeeded;Failed;Running
-type ArchiveRunResult string
-
-const (
-	ArchiveRunSucceeded ArchiveRunResult = "Succeeded"
-	ArchiveRunFailed    ArchiveRunResult = "Failed"
-	ArchiveRunRunning   ArchiveRunResult = "Running"
-)
-
 // AnnotationTriggerTime, when set on an ArchiveRule, requests that the
 // operator fire an immediate archive run regardless of the cron schedule.
 // The annotation value must be RFC3339-formatted; the reconciler tracks
@@ -94,10 +84,6 @@ type ArchiveRuleStatus struct {
 	// +optional
 	LastRunTime *metav1.Time `json:"lastRunTime,omitempty"`
 
-	// LastRunResult is the terminal result of the most recent run.
-	// +optional
-	LastRunResult ArchiveRunResult `json:"lastRunResult,omitempty"`
-
 	// LastRunRowsArchived is the row count from the most recent run.
 	// +optional
 	LastRunRowsArchived int64 `json:"lastRunRowsArchived,omitempty"`
@@ -125,6 +111,13 @@ type ArchiveRuleStatus struct {
 	// +optional
 	ConsecutiveFailures int32 `json:"consecutiveFailures,omitempty"`
 
+	// Conditions report the latest observed state of the rule. Standard types:
+	//
+	//   Ready          rule is configured correctly and not auto-suspended
+	//   ScheduleValid  spec.schedule parses as a cron expression
+	//   Progressing    an archive Job is currently running
+	//   Degraded       most recent run failed (or consecutive failures > 0)
+	//
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -142,7 +135,9 @@ type ArchiveRuleStatus struct {
 // +kubebuilder:printcolumn:name="Table",type=string,JSONPath=`.spec.table`
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
 // +kubebuilder:printcolumn:name="Days-Online",type=integer,JSONPath=`.spec.daysOnline`
-// +kubebuilder:printcolumn:name="Last-Result",type=string,JSONPath=`.status.lastRunResult`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Degraded",type=string,JSONPath=`.status.conditions[?(@.type=="Degraded")].status`
 // +kubebuilder:printcolumn:name="Rows-Archived",type=integer,JSONPath=`.status.lastRunRowsArchived`
 // +kubebuilder:printcolumn:name="Next-Run",type=date,JSONPath=`.status.nextScheduledTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/api/v1alpha1/restorerequest_types.go
+++ b/api/v1alpha1/restorerequest_types.go
@@ -8,17 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RestorePhase tracks the lifecycle of a one-shot restore.
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
-type RestorePhase string
-
-const (
-	RestorePending   RestorePhase = "Pending"
-	RestoreRunning   RestorePhase = "Running"
-	RestoreSucceeded RestorePhase = "Succeeded"
-	RestoreFailed    RestorePhase = "Failed"
-)
-
 // RestoreRequestSpec is immutable after creation. To re-run a restore,
 // create a new RestoreRequest.
 type RestoreRequestSpec struct {
@@ -42,12 +31,10 @@ type RestoreRequestSpec struct {
 	Table string `json:"table,omitempty"`
 }
 
-// RestoreRequestStatus tracks one-shot restore execution.
+// RestoreRequestStatus tracks one-shot restore execution. Lifecycle is
+// expressed via Conditions (the ad-hoc Phase field was removed in favor of
+// the standard metav1.Condition pattern).
 type RestoreRequestStatus struct {
-	// Phase is the lifecycle phase of this restore.
-	// +optional
-	Phase RestorePhase `json:"phase,omitempty"`
-
 	// JobRef points to the Job spawned by this request.
 	// +optional
 	JobRef *corev1.LocalObjectReference `json:"jobRef,omitempty"`
@@ -64,6 +51,17 @@ type RestoreRequestStatus struct {
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
+	// Conditions report the latest observed state of the restore. Standard
+	// types:
+	//
+	//   Ready        request is well-formed and references resolve
+	//   Progressing  Job is running
+	//   Succeeded    Job completed successfully (terminal)
+	//   Failed       Job failed terminally
+	//
+	// At most one of Succeeded / Failed will be True at a time, and only
+	// after the Job reaches a terminal state.
+	//
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -80,7 +78,9 @@ type RestoreRequestStatus struct {
 // +kubebuilder:resource:shortName=rr,categories=apr
 // +kubebuilder:printcolumn:name="Rule",type=string,JSONPath=`.spec.archiveRuleRef.name`
 // +kubebuilder:printcolumn:name="Date",type=string,JSONPath=`.spec.date`
-// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].status`
+// +kubebuilder:printcolumn:name="Failed",type=string,JSONPath=`.status.conditions[?(@.type=="Failed")].status`
 // +kubebuilder:printcolumn:name="Rows-Restored",type=integer,JSONPath=`.status.rowsRestored`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/charts/apr/crds/apr.dev_archiverules.yaml
+++ b/charts/apr/crds/apr.dev_archiverules.yaml
@@ -28,8 +28,14 @@ spec:
     - jsonPath: .spec.daysOnline
       name: Days-Online
       type: integer
-    - jsonPath: .status.lastRunResult
-      name: Last-Result
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
       type: string
     - jsonPath: .status.lastRunRowsArchived
       name: Rows-Archived
@@ -173,6 +179,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               conditions:
+                description: |-
+                  Conditions report the latest observed state of the rule. Standard types:
+
+                    Ready          rule is configured correctly and not auto-suspended
+                    ScheduleValid  spec.schedule parses as a cron expression
+                    Progressing    an archive Job is currently running
+                    Degraded       most recent run failed (or consecutive failures > 0)
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -258,14 +271,6 @@ spec:
               lastRunID:
                 description: LastRunID is the engine's run ID for the most recent
                   run.
-                type: string
-              lastRunResult:
-                description: LastRunResult is the terminal result of the most recent
-                  run.
-                enum:
-                - Succeeded
-                - Failed
-                - Running
                 type: string
               lastRunRowsArchived:
                 description: LastRunRowsArchived is the row count from the most recent

--- a/charts/apr/crds/apr.dev_restorerequests.yaml
+++ b/charts/apr/crds/apr.dev_restorerequests.yaml
@@ -25,8 +25,14 @@ spec:
     - jsonPath: .spec.date
       name: Date
       type: string
-    - jsonPath: .status.phase
-      name: Phase
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Failed")].status
+      name: Failed
       type: string
     - jsonPath: .status.rowsRestored
       name: Rows-Restored
@@ -97,13 +103,27 @@ spec:
             - archiveRuleRef
             type: object
           status:
-            description: RestoreRequestStatus tracks one-shot restore execution.
+            description: |-
+              RestoreRequestStatus tracks one-shot restore execution. Lifecycle is
+              expressed via Conditions (the ad-hoc Phase field was removed in favor of
+              the standard metav1.Condition pattern).
             properties:
               completionTime:
                 description: CompletionTime is when the Job reached a terminal phase.
                 format: date-time
                 type: string
               conditions:
+                description: |-
+                  Conditions report the latest observed state of the restore. Standard
+                  types:
+
+                    Ready        request is well-formed and references resolve
+                    Progressing  Job is running
+                    Succeeded    Job completed successfully (terminal)
+                    Failed       Job failed terminally
+
+                  At most one of Succeeded / Failed will be True at a time, and only
+                  after the Job reaches a terminal state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -179,14 +199,6 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
-              phase:
-                description: Phase is the lifecycle phase of this restore.
-                enum:
-                - Pending
-                - Running
-                - Succeeded
-                - Failed
-                type: string
               rowsRestored:
                 description: RowsRestored is the total row count across all restored
                   tables.

--- a/config/crd/bases/apr.dev_archiverules.yaml
+++ b/config/crd/bases/apr.dev_archiverules.yaml
@@ -28,8 +28,14 @@ spec:
     - jsonPath: .spec.daysOnline
       name: Days-Online
       type: integer
-    - jsonPath: .status.lastRunResult
-      name: Last-Result
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
       type: string
     - jsonPath: .status.lastRunRowsArchived
       name: Rows-Archived
@@ -173,6 +179,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               conditions:
+                description: |-
+                  Conditions report the latest observed state of the rule. Standard types:
+
+                    Ready          rule is configured correctly and not auto-suspended
+                    ScheduleValid  spec.schedule parses as a cron expression
+                    Progressing    an archive Job is currently running
+                    Degraded       most recent run failed (or consecutive failures > 0)
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -258,14 +271,6 @@ spec:
               lastRunID:
                 description: LastRunID is the engine's run ID for the most recent
                   run.
-                type: string
-              lastRunResult:
-                description: LastRunResult is the terminal result of the most recent
-                  run.
-                enum:
-                - Succeeded
-                - Failed
-                - Running
                 type: string
               lastRunRowsArchived:
                 description: LastRunRowsArchived is the row count from the most recent

--- a/config/crd/bases/apr.dev_restorerequests.yaml
+++ b/config/crd/bases/apr.dev_restorerequests.yaml
@@ -25,8 +25,14 @@ spec:
     - jsonPath: .spec.date
       name: Date
       type: string
-    - jsonPath: .status.phase
-      name: Phase
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Failed")].status
+      name: Failed
       type: string
     - jsonPath: .status.rowsRestored
       name: Rows-Restored
@@ -97,13 +103,27 @@ spec:
             - archiveRuleRef
             type: object
           status:
-            description: RestoreRequestStatus tracks one-shot restore execution.
+            description: |-
+              RestoreRequestStatus tracks one-shot restore execution. Lifecycle is
+              expressed via Conditions (the ad-hoc Phase field was removed in favor of
+              the standard metav1.Condition pattern).
             properties:
               completionTime:
                 description: CompletionTime is when the Job reached a terminal phase.
                 format: date-time
                 type: string
               conditions:
+                description: |-
+                  Conditions report the latest observed state of the restore. Standard
+                  types:
+
+                    Ready        request is well-formed and references resolve
+                    Progressing  Job is running
+                    Succeeded    Job completed successfully (terminal)
+                    Failed       Job failed terminally
+
+                  At most one of Succeeded / Failed will be True at a time, and only
+                  after the Job reaches a terminal state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -179,14 +199,6 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
-              phase:
-                description: Phase is the lifecycle phase of this restore.
-                enum:
-                - Pending
-                - Running
-                - Succeeded
-                - Failed
-                type: string
               rowsRestored:
                 description: RowsRestored is the total row count across all restored
                   tables.

--- a/docs/install.md
+++ b/docs/install.md
@@ -69,8 +69,8 @@ databaseconnection.apr.dev/orders-db  postgres   postgres.data.svc.cluster.local
 NAME                                STATUS   TYPE         BUCKET           READY   AGE
 storagebackend.apr.dev/archive-pvc           filesystem   /var/archives    True    5s
 
-NAME                                    TABLE    SCHEDULE    DAYS-ONLINE   LAST-RESULT   ROWS-ARCHIVED   NEXT-RUN   AGE
-archiverule.apr.dev/orders-archive      orders   0 2 * * *   90                                          ...        5s
+NAME                                    TABLE    SCHEDULE    DAYS-ONLINE   READY   PROGRESSING   DEGRADED   ROWS-ARCHIVED   NEXT-RUN   AGE
+archiverule.apr.dev/orders-archive      orders   0 2 * * *   90            True    False         False                       ...        5s
 ```
 
 If `READY=True` doesn't appear, inspect the resource for the failure
@@ -80,13 +80,13 @@ reason:
 kubectl -n data describe archiverule orders-archive
 ```
 
-The operator creates a `CronJob` named `archiverule-orders-archive` in the
-same namespace. To trigger an immediate run rather than waiting for the
-schedule to fire:
+The operator owns the cron schedule itself and spawns archive `Job`s
+directly (no `CronJob`). To trigger an immediate run rather than waiting
+for the schedule to fire, set the `apr.dev/trigger-time` annotation:
 
 ```bash
-kubectl -n data create job orders-archive-manual \
-  --from=cronjob/archiverule-orders-archive
+kubectl -n data annotate archiverule orders-archive \
+  apr.dev/trigger-time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
 ```
 
 Watch the resulting pod:
@@ -96,12 +96,26 @@ kubectl -n data get jobs,pods
 kubectl -n data logs -l app.kubernetes.io/name=apr,apr.dev/archive-rule=orders-archive
 ```
 
-After the Job completes, the rule's status reflects the run:
+After the Job completes, the rule's status reflects the run via standard
+Kubernetes conditions:
 
 ```bash
 kubectl -n data get archiverule orders-archive
-# NAME              ...  LAST-RESULT  ROWS-ARCHIVED  ...
-# orders-archive    ...  Succeeded    14823          ...
+# NAME              ...  READY  PROGRESSING  DEGRADED  ROWS-ARCHIVED  ...
+# orders-archive    ...  True   False        False     14823          ...
+```
+
+You can wait for any condition with `kubectl wait`:
+
+```bash
+# Wait until configuration is healthy.
+kubectl -n data wait archiverule/orders-archive --for=condition=Ready --timeout=60s
+
+# Wait for an in-flight run to finish.
+kubectl -n data wait archiverule/orders-archive --for=condition=Progressing=False --timeout=10m
+
+# Block on a healthy state (no recent failures).
+kubectl -n data wait archiverule/orders-archive --for=condition=Degraded=False --timeout=60s
 ```
 
 ## Restore on demand
@@ -122,13 +136,43 @@ spec:
 EOF
 ```
 
-Check progress:
+Check progress (lifecycle is exposed via standard conditions —
+`Progressing` flips True while the Job runs, then `Succeeded` or `Failed`
+becomes True at the terminal state):
 
 ```bash
 kubectl -n data get restorerequest
-# NAME                            RULE             DATE         PHASE       ROWS-RESTORED  AGE
-# restore-orders-2026-04-01       orders-archive   2026-04-01   Succeeded   14823          30s
+# NAME                            RULE             DATE         PROGRESSING   SUCCEEDED   FAILED   ROWS-RESTORED  AGE
+# restore-orders-2026-04-01       orders-archive   2026-04-01   False         True        False    14823          30s
 ```
+
+Or block on completion:
+
+```bash
+kubectl -n data wait restorerequest/restore-orders-2026-04-01 \
+  --for=condition=Succeeded --timeout=10m
+```
+
+## Standard conditions
+
+APR follows the Kubernetes API convention of exposing state via
+`metav1.Condition`. The full vocabulary per kind:
+
+| Kind | Condition | Meaning |
+|---|---|---|
+| `DatabaseConnection`, `StorageBackend` | `Ready` | Credentials Secret exists with required keys |
+| `ArchiveRule` | `Ready` | Rule is configured correctly and not auto-suspended |
+| `ArchiveRule` | `ScheduleValid` | `spec.schedule` parses as a cron expression |
+| `ArchiveRule` | `Progressing` | An archive Job is currently running |
+| `ArchiveRule` | `Degraded` | Most recent run failed (or auto-suspended after `maxFailures`) |
+| `RestoreRequest` | `Ready` | Request is well-formed and references resolve |
+| `RestoreRequest` | `Progressing` | Job is running |
+| `RestoreRequest` | `Succeeded` | Job completed successfully (terminal) |
+| `RestoreRequest` | `Failed` | Job failed terminally |
+
+These work transparently with `kubectl wait --for=condition=...` and with
+GitOps tooling like ArgoCD or Flux that interpret `metav1.Condition`s as
+generic resource health.
 
 ## Uninstall
 

--- a/docs/kubernetes-operator-plan.md
+++ b/docs/kubernetes-operator-plan.md
@@ -144,16 +144,22 @@ spec:
   batchSize: 10000                   # optional, defaults to engine default
   suspend: false                     # mirrors CronJob.spec.suspend
 status:
-  cronJobRef:
-    name: archiverule-orders-archive
+  lastJobRef:
+    name: orders-archive-x7k2p
   lastRunTime: 2026-05-06T02:00:00Z
-  lastRunResult: Succeeded           # Succeeded | Failed | Running
   lastRunRowsArchived: 14823
   lastRunID: 9f3a2b1c
   nextScheduledTime: 2026-05-07T02:00:00Z
+  consecutiveFailures: 0
   conditions:
-    - type: Ready
+    - type: Ready          # rule is configured and not auto-suspended
       status: "True"
+    - type: ScheduleValid  # cron expression parses
+      status: "True"
+    - type: Progressing    # an archive Job is currently running
+      status: "False"
+    - type: Degraded       # most recent run failed (or auto-suspended)
+      status: "False"
 ```
 
 The controller reconciles this into a `CronJob` named `archiverule-{name}` in the same namespace. The Job pod runs `apr archive` against a generated config materialized from the CR plus its referenced `DatabaseConnection` and `StorageBackend`. Credentials are projected as env vars from the referenced Secrets.
@@ -172,15 +178,23 @@ spec:
   date: "2026-04-01"                 # optional filter
   runID: 9f3a2b1c                    # optional filter
 status:
-  phase: Succeeded                   # Pending | Running | Succeeded | Failed
   jobRef:
     name: restorerequest-restore-orders-2026-04-01
   rowsRestored: 14823
   startTime: ...
   completionTime: ...
+  conditions:
+    - type: Ready          # request is well-formed and references resolve
+      status: "True"
+    - type: Progressing    # Job is running
+      status: "False"
+    - type: Succeeded      # Job completed successfully (terminal)
+      status: "True"
+    - type: Failed         # Job failed terminally
+      status: "False"
 ```
 
-The controller reconciles `RestoreRequest` into a one-shot `Job`. After `Job` completion the controller updates `status.phase` and is done — restore requests are immutable; to re-run, create a new CR.
+The controller reconciles `RestoreRequest` into a one-shot `Job`. After `Job` completion the controller flips `Succeeded` or `Failed` to `True` and is done — restore requests are immutable; to re-run, create a new CR.
 
 ### Execution model
 

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -162,6 +162,14 @@ func TestEndToEnd_ArchiveAndRestore(t *testing.T) {
 		t.Error("LastRunRowsArchived = 0; expected old rows to be archived")
 	}
 
+	// Verify the standard metav1.Condition vocabulary that
+	// `kubectl wait --for=condition=...` relies on. Each of these checks
+	// is what a user (or ArgoCD/Flux) would query.
+	requireConditionState(t, finalRule.Status.Conditions, "Ready", metav1.ConditionTrue)
+	requireConditionState(t, finalRule.Status.Conditions, "ScheduleValid", metav1.ConditionTrue)
+	requireConditionState(t, finalRule.Status.Conditions, "Progressing", metav1.ConditionFalse)
+	requireConditionState(t, finalRule.Status.Conditions, "Degraded", metav1.ConditionFalse)
+
 	// Phase 3: rows older than 90 days should be gone from Postgres.
 	afterArchiveCount := countOrders(t, ctx, db)
 	if afterArchiveCount >= initialCount {
@@ -184,6 +192,10 @@ func TestEndToEnd_ArchiveAndRestore(t *testing.T) {
 	if rr.Status.RowsRestored == 0 {
 		t.Error("RowsRestored = 0; expected restore to insert archived rows back")
 	}
+
+	requireConditionState(t, rr.Status.Conditions, "Succeeded", metav1.ConditionTrue)
+	requireConditionState(t, rr.Status.Conditions, "Failed", metav1.ConditionFalse)
+	requireConditionState(t, rr.Status.Conditions, "Progressing", metav1.ConditionFalse)
 
 	// Phase 6: Postgres should be back to the initial row count.
 	afterRestoreCount := countOrders(t, ctx, db)
@@ -418,10 +430,11 @@ func waitForArchiveRuleReady(t *testing.T, ctx context.Context, c client.Client,
 	return &got
 }
 
-// waitForArchiveSucceeded waits until BOTH LastRunResult=Succeeded (set by
-// the Job pod's sink) AND LastJobRef is populated (set by the operator's
-// reconciler when it observes the finished Job). These two writes happen
-// independently; without waiting for both we'd race the reconciler.
+// waitForArchiveSucceeded waits until BOTH the Degraded condition flips to
+// False/LastRunSucceeded (set by the Job pod's sink) AND LastJobRef is
+// populated (set by the operator's reconciler when it observes the
+// finished Job). These two writes happen independently; without waiting
+// for both we'd race the reconciler.
 func waitForArchiveSucceeded(t *testing.T, ctx context.Context, c client.Client, ns, name string, timeout time.Duration) *aprv1alpha1.ArchiveRule {
 	t.Helper()
 	var got aprv1alpha1.ArchiveRule
@@ -429,9 +442,12 @@ func waitForArchiveSucceeded(t *testing.T, ctx context.Context, c client.Client,
 		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &got); err != nil {
 			return false
 		}
-		return got.Status.LastRunResult == aprv1alpha1.ArchiveRunSucceeded &&
+		degraded := apimeta.FindStatusCondition(got.Status.Conditions, "Degraded")
+		return degraded != nil &&
+			degraded.Status == metav1.ConditionFalse &&
+			degraded.Reason == "LastRunSucceeded" &&
 			got.Status.LastJobRef != nil
-	}, fmt.Sprintf("ArchiveRule %s/%s LastRunResult=Succeeded with LastJobRef", ns, name))
+	}, fmt.Sprintf("ArchiveRule %s/%s Degraded=False/LastRunSucceeded with LastJobRef", ns, name))
 	return &got
 }
 
@@ -442,8 +458,9 @@ func waitForRestoreSucceeded(t *testing.T, ctx context.Context, c client.Client,
 		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &got); err != nil {
 			return false
 		}
-		return got.Status.Phase == aprv1alpha1.RestoreSucceeded
-	}, fmt.Sprintf("RestoreRequest %s/%s Phase=Succeeded", ns, name))
+		succeeded := apimeta.FindStatusCondition(got.Status.Conditions, "Succeeded")
+		return succeeded != nil && succeeded.Status == metav1.ConditionTrue
+	}, fmt.Sprintf("RestoreRequest %s/%s Succeeded=True", ns, name))
 	return &got
 }
 
@@ -466,6 +483,23 @@ func triggerArchiveRule(t *testing.T, ctx context.Context, c client.Client, ns, 
 		t.Fatalf("patching trigger annotation: %v", err)
 	}
 	t.Logf("triggered archive rule %s/%s via annotation", ns, name)
+}
+
+// requireConditionState asserts that the named condition is present and
+// has the given Status. This mirrors what `kubectl wait --for=condition=X`
+// checks: the kubectl client side reads the same metav1.Condition slice
+// and matches on Type+Status.
+func requireConditionState(t *testing.T, conds []metav1.Condition, condType string, want metav1.ConditionStatus) {
+	t.Helper()
+	got := apimeta.FindStatusCondition(conds, condType)
+	if got == nil {
+		t.Errorf("expected condition %q, none set; conds=%+v", condType, conds)
+		return
+	}
+	if got.Status != want {
+		t.Errorf("condition %q = %s, want %s (reason=%q, message=%q)",
+			condType, got.Status, want, got.Reason, got.Message)
+	}
 }
 
 func listCronJobs(t *testing.T, ctx context.Context, c client.Client, ns string) []batchv1.CronJob {

--- a/internal/cluster/run.go
+++ b/internal/cluster/run.go
@@ -68,7 +68,7 @@ func RunArchiveFromCR(ctx context.Context, c client.Client, ref string, logger *
 	result, runErr := eng.RunArchive(ctx, ec.Rule.Name, db)
 
 	// Record the outcome regardless of whether the run succeeded; we want
-	// LastRunResult=Failed on failure so users can see it via kubectl.
+	// the Degraded condition flipped on failure so users see it via kubectl.
 	if recErr := RecordArchiveResult(ctx, c, namespace, name, result, runErr); recErr != nil {
 		logger.Error("recording archive result", "error", recErr)
 	}

--- a/internal/cluster/sink.go
+++ b/internal/cluster/sink.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aprv1alpha1 "github.com/carlos-loya/archive-purge-restore/api/v1alpha1"
+	"github.com/carlos-loya/archive-purge-restore/internal/controller"
 	"github.com/carlos-loya/archive-purge-restore/internal/engine"
 )
 
@@ -24,8 +26,9 @@ import (
 const maxStatusRetries = 5
 
 // RecordArchiveResult patches ArchiveRule.status with the outcome of an
-// engine.RunArchive call. It only touches LastRun* fields — Conditions,
-// CronJobRef, and NextScheduledTime are owned by the operator's reconciler.
+// engine.RunArchive call. It writes the LastRun* fields and the Degraded
+// condition. ScheduleValid, Progressing, Ready, ActiveJobRef, LastJobRef,
+// and NextScheduledTime are owned by the operator's reconciler.
 func RecordArchiveResult(
 	ctx context.Context,
 	c client.Client,
@@ -55,21 +58,45 @@ func applyArchiveResult(rule *aprv1alpha1.ArchiveRule, result *engine.RunResult,
 	rule.Status.LastRunID = result.RunID
 
 	var rows int64
-	tableErr := false
+	var firstTableErr error
 	for _, t := range result.Tables {
 		rows += t.RowsArchived
-		if t.Error != nil {
-			tableErr = true
+		if t.Error != nil && firstTableErr == nil {
+			firstTableErr = t.Error
 		}
 	}
 	rule.Status.LastRunRowsArchived = rows
 
 	switch {
-	case runErr != nil, tableErr:
-		rule.Status.LastRunResult = aprv1alpha1.ArchiveRunFailed
+	case runErr != nil:
+		setCond(&rule.Status.Conditions, controller.ConditionDegraded, metav1.ConditionTrue,
+			controller.ReasonLastRunFailed,
+			fmt.Sprintf("archive run failed: %v", runErr),
+			rule.Generation)
+	case firstTableErr != nil:
+		setCond(&rule.Status.Conditions, controller.ConditionDegraded, metav1.ConditionTrue,
+			controller.ReasonLastRunFailed,
+			fmt.Sprintf("at least one table failed to archive: %v", firstTableErr),
+			rule.Generation)
 	default:
-		rule.Status.LastRunResult = aprv1alpha1.ArchiveRunSucceeded
+		setCond(&rule.Status.Conditions, controller.ConditionDegraded, metav1.ConditionFalse,
+			controller.ReasonLastRunSucceeded,
+			fmt.Sprintf("archive run %q completed successfully (rows=%d)", result.RunID, rows),
+			rule.Generation)
 	}
+}
+
+// setCond is a thin wrapper over apimeta.SetStatusCondition kept local to
+// the sink to avoid pulling more controller-internal helpers into this
+// pod-side codepath.
+func setCond(conds *[]metav1.Condition, condType string, status metav1.ConditionStatus, reason, message string, generation int64) {
+	apimeta.SetStatusCondition(conds, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: generation,
+	})
 }
 
 // RecordRestoreResult patches RestoreRequest.status with the outcome of an
@@ -93,9 +120,10 @@ func RecordRestoreResult(
 }
 
 // applyRestoreResult writes the per-run details of a restore. It does NOT
-// touch RestoreRequest.status.Phase — that field is owned by the operator's
-// RestoreRequestReconciler, which derives it from observed Job state. This
-// avoids a write race between the in-cluster reconciler and the Job pod.
+// touch the lifecycle conditions (Progressing / Succeeded / Failed) —
+// those are owned by the operator's RestoreRequestReconciler, which
+// derives them from observed Job state. This avoids a write race between
+// the in-cluster reconciler and the Job pod.
 func applyRestoreResult(
 	rr *aprv1alpha1.RestoreRequest,
 	result *engine.RestoreResult,

--- a/internal/cluster/sink_test.go
+++ b/internal/cluster/sink_test.go
@@ -8,7 +8,11 @@ import (
 	"testing"
 	"time"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	aprv1alpha1 "github.com/carlos-loya/archive-purge-restore/api/v1alpha1"
+	"github.com/carlos-loya/archive-purge-restore/internal/controller"
 	"github.com/carlos-loya/archive-purge-restore/internal/engine"
 )
 
@@ -25,9 +29,7 @@ func TestApplyArchiveResult_Success(t *testing.T) {
 	}
 	applyArchiveResult(rule, result, nil)
 
-	if rule.Status.LastRunResult != aprv1alpha1.ArchiveRunSucceeded {
-		t.Errorf("LastRunResult = %q, want Succeeded", rule.Status.LastRunResult)
-	}
+	requireDegraded(t, rule.Status.Conditions, metav1.ConditionFalse, controller.ReasonLastRunSucceeded)
 	if rule.Status.LastRunRowsArchived != 150 {
 		t.Errorf("LastRunRowsArchived = %d, want 150", rule.Status.LastRunRowsArchived)
 	}
@@ -47,9 +49,7 @@ func TestApplyArchiveResult_RunError(t *testing.T) {
 	}
 	applyArchiveResult(rule, result, errors.New("connection refused"))
 
-	if rule.Status.LastRunResult != aprv1alpha1.ArchiveRunFailed {
-		t.Errorf("LastRunResult = %q, want Failed", rule.Status.LastRunResult)
-	}
+	requireDegraded(t, rule.Status.Conditions, metav1.ConditionTrue, controller.ReasonLastRunFailed)
 	if rule.Status.LastRunRowsArchived != 50 {
 		t.Errorf("partial row count not preserved: %d", rule.Status.LastRunRowsArchived)
 	}
@@ -66,20 +66,16 @@ func TestApplyArchiveResult_PerTableError(t *testing.T) {
 	}
 	applyArchiveResult(rule, result, nil)
 
-	if rule.Status.LastRunResult != aprv1alpha1.ArchiveRunFailed {
-		t.Errorf("any table error should mark the run Failed; got %q", rule.Status.LastRunResult)
-	}
+	requireDegraded(t, rule.Status.Conditions, metav1.ConditionTrue, controller.ReasonLastRunFailed)
 }
 
 func TestApplyArchiveResult_NilResult(t *testing.T) {
 	rule := &aprv1alpha1.ArchiveRule{}
 	applyArchiveResult(rule, nil, errors.New("setup failed before engine ran"))
-	if rule.Status.LastRunResult != aprv1alpha1.ArchiveRunFailed {
-		t.Errorf("nil result with error should be Failed, got %q", rule.Status.LastRunResult)
-	}
+	requireDegraded(t, rule.Status.Conditions, metav1.ConditionTrue, controller.ReasonLastRunFailed)
 }
 
-func TestApplyRestoreResult_WritesDetailsButNotPhase(t *testing.T) {
+func TestApplyRestoreResult_WritesDetailsButNotConditions(t *testing.T) {
 	rr := &aprv1alpha1.RestoreRequest{}
 	start := time.Date(2026, 5, 6, 14, 0, 0, 0, time.UTC)
 	result := &engine.RestoreResult{
@@ -98,16 +94,40 @@ func TestApplyRestoreResult_WritesDetailsButNotPhase(t *testing.T) {
 	if rr.Status.CompletionTime == nil {
 		t.Error("CompletionTime not set")
 	}
-	// Sink must NOT touch Phase — that's the reconciler's responsibility.
-	if rr.Status.Phase != "" {
-		t.Errorf("Phase should be untouched by sink, got %q", rr.Status.Phase)
+	// Sink must NOT touch lifecycle conditions — that's the reconciler's
+	// responsibility (avoids a write race with the Job pod).
+	for _, ct := range []string{controller.ConditionProgressing, controller.ConditionSucceeded, controller.ConditionFailed} {
+		if c := apimeta.FindStatusCondition(rr.Status.Conditions, ct); c != nil {
+			t.Errorf("sink should not touch %s, got %+v", ct, c)
+		}
 	}
 }
 
-func TestApplyRestoreResult_PhaseUntouchedOnError(t *testing.T) {
-	rr := &aprv1alpha1.RestoreRequest{Status: aprv1alpha1.RestoreRequestStatus{Phase: aprv1alpha1.RestoreRunning}}
+func TestApplyRestoreResult_ConditionsUntouchedOnError(t *testing.T) {
+	rr := &aprv1alpha1.RestoreRequest{
+		Status: aprv1alpha1.RestoreRequestStatus{
+			Conditions: []metav1.Condition{{
+				Type:   controller.ConditionProgressing,
+				Status: metav1.ConditionTrue,
+				Reason: controller.ReasonRestoreRunning,
+			}},
+		},
+	}
 	applyRestoreResult(rr, nil, errors.New("database closed connection"), time.Now())
-	if rr.Status.Phase != aprv1alpha1.RestoreRunning {
-		t.Errorf("sink should never touch Phase, got %q", rr.Status.Phase)
+	c := apimeta.FindStatusCondition(rr.Status.Conditions, controller.ConditionProgressing)
+	if c == nil || c.Status != metav1.ConditionTrue {
+		t.Errorf("sink should never touch Progressing, got %+v", c)
+	}
+}
+
+func requireDegraded(t *testing.T, conds []metav1.Condition, status metav1.ConditionStatus, reason string) {
+	t.Helper()
+	c := apimeta.FindStatusCondition(conds, controller.ConditionDegraded)
+	if c == nil {
+		t.Fatalf("Degraded condition not set; conds=%+v", conds)
+	}
+	if c.Status != status || c.Reason != reason {
+		t.Fatalf("Degraded = {Status:%s, Reason:%s}, want {Status:%s, Reason:%s}",
+			c.Status, c.Reason, status, reason)
 	}
 }

--- a/internal/controller/archiverule_controller.go
+++ b/internal/controller/archiverule_controller.go
@@ -86,9 +86,17 @@ func (r *ArchiveRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	sched, err := cron.ParseStandard(rule.Spec.Schedule)
 	if err != nil {
+		setCondition(&rule.Status.Conditions, ConditionScheduleValid, metav1.ConditionFalse,
+			ReasonInvalidSchedule,
+			fmt.Sprintf("invalid cron expression %q: %v", rule.Spec.Schedule, err),
+			rule.Generation)
 		return r.setNotReady(ctx, &rule, ReasonInvalidSchedule,
 			fmt.Sprintf("invalid cron expression %q: %v", rule.Spec.Schedule, err))
 	}
+	setCondition(&rule.Status.Conditions, ConditionScheduleValid, metav1.ConditionTrue,
+		ReasonScheduleParsed,
+		fmt.Sprintf("cron expression %q parses", rule.Spec.Schedule),
+		rule.Generation)
 
 	ownedJobs, err := r.listOwnedJobs(ctx, &rule)
 	if err != nil {
@@ -168,33 +176,64 @@ func (r *ArchiveRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	// Set the Ready condition based on our decision.
+	// Set Progressing based on whether a Job is currently running.
+	if active != nil {
+		setCondition(&rule.Status.Conditions, ConditionProgressing, metav1.ConditionTrue,
+			ReasonJobActive,
+			fmt.Sprintf("archive Job %q is running", active.Name),
+			rule.Generation)
+	} else {
+		setCondition(&rule.Status.Conditions, ConditionProgressing, metav1.ConditionFalse,
+			ReasonJobIdle,
+			"no archive Job is currently running",
+			rule.Generation)
+	}
+
+	// Set Degraded:
+	//   - True/MaxFailuresReached when auto-suspended.
+	//   - True/LastRunFailed when the most recent finished Job failed (set
+	//     here defensively so users see Degraded even if the sink in the
+	//     Job pod did not run, e.g. crashed pod).
+	//   - False/LastRunSucceeded when the most recent finished Job succeeded.
+	//   - Otherwise leave alone (no finished Jobs yet → no signal).
 	switch {
 	case autoSuspended:
-		apimeta.SetStatusCondition(&rule.Status.Conditions, metav1.Condition{
-			Type:               ConditionReady,
-			Status:             metav1.ConditionFalse,
-			Reason:             ReasonMaxFailuresReached,
-			Message: fmt.Sprintf("ConsecutiveFailures=%d reached MaxFailures=%d; clear the annotation %s or fix the underlying cause to resume",
+		setCondition(&rule.Status.Conditions, ConditionDegraded, metav1.ConditionTrue,
+			ReasonMaxFailuresReached,
+			fmt.Sprintf("ConsecutiveFailures=%d reached MaxFailures=%d", rule.Status.ConsecutiveFailures, failureLimit),
+			rule.Generation)
+	case lastFinished != nil && !didJobSucceed(lastFinished):
+		setCondition(&rule.Status.Conditions, ConditionDegraded, metav1.ConditionTrue,
+			ReasonLastRunFailed,
+			fmt.Sprintf("most recent archive Job %q failed", lastFinished.Name),
+			rule.Generation)
+	case lastFinished != nil && didJobSucceed(lastFinished):
+		setCondition(&rule.Status.Conditions, ConditionDegraded, metav1.ConditionFalse,
+			ReasonLastRunSucceeded,
+			fmt.Sprintf("most recent archive Job %q succeeded", lastFinished.Name),
+			rule.Generation)
+	}
+
+	// Set Ready last — it summarizes the rule's overall configuration
+	// health. Auto-suspend flips Ready=False because no further runs will
+	// be scheduled until a manual fix.
+	switch {
+	case autoSuspended:
+		setCondition(&rule.Status.Conditions, ConditionReady, metav1.ConditionFalse,
+			ReasonMaxFailuresReached,
+			fmt.Sprintf("ConsecutiveFailures=%d reached MaxFailures=%d; clear the annotation %s or fix the underlying cause to resume",
 				rule.Status.ConsecutiveFailures, failureLimit, aprv1alpha1.AnnotationTriggerTime),
-			ObservedGeneration: rule.Generation,
-		})
+			rule.Generation)
 	case rule.Spec.Suspend:
-		apimeta.SetStatusCondition(&rule.Status.Conditions, metav1.Condition{
-			Type:               ConditionReady,
-			Status:             metav1.ConditionTrue,
-			Reason:             ReasonSuspended,
-			Message:            "rule suspended by spec.suspend",
-			ObservedGeneration: rule.Generation,
-		})
+		setCondition(&rule.Status.Conditions, ConditionReady, metav1.ConditionTrue,
+			ReasonSuspended,
+			"rule suspended by spec.suspend",
+			rule.Generation)
 	default:
-		apimeta.SetStatusCondition(&rule.Status.Conditions, metav1.Condition{
-			Type:               ConditionReady,
-			Status:             metav1.ConditionTrue,
-			Reason:             ReasonReady,
-			Message:            "rule scheduled",
-			ObservedGeneration: rule.Generation,
-		})
+		setCondition(&rule.Status.Conditions, ConditionReady, metav1.ConditionTrue,
+			ReasonReady,
+			"rule scheduled",
+			rule.Generation)
 	}
 	rule.Status.ObservedGeneration = rule.Generation
 
@@ -333,12 +372,12 @@ func countConsecutiveFailures(jobs []batchv1.Job) int32 {
 // Conventions:
 //
 //   - The Job pod's sink (cluster.RecordArchiveResult) is the source of
-//     truth for LastRunResult/LastRunRowsArchived/LastRunID/LastRunTime
-//     when the engine actually ran. The reconciler does NOT touch those
-//     fields on a successful Job.
+//     truth for LastRunRowsArchived/LastRunID/LastRunTime AND for the
+//     Degraded condition when the engine actually ran.
 //   - When a Job terminated with Failed and the sink may not have run
-//     (pod crashed before the engine returned), we override
-//     LastRunResult to Failed so users see the correct outcome.
+//     (pod crashed before the engine returned), the reconciler still
+//     advances LastRunTime so users see the failed run, and the main
+//     Reconcile loop sets Degraded=True/LastRunFailed.
 //   - LastJobRef and ActiveJobRef are owned by the reconciler.
 func (r *ArchiveRuleReconciler) applyJobStatus(rule *aprv1alpha1.ArchiveRule, active, lastFinished *batchv1.Job) {
 	if active != nil {
@@ -348,12 +387,9 @@ func (r *ArchiveRuleReconciler) applyJobStatus(rule *aprv1alpha1.ArchiveRule, ac
 	}
 	if lastFinished != nil {
 		rule.Status.LastJobRef = &corev1.LocalObjectReference{Name: lastFinished.Name}
-		if !didJobSucceed(lastFinished) {
-			rule.Status.LastRunResult = aprv1alpha1.ArchiveRunFailed
-			if lastFinished.Status.StartTime != nil &&
-				(rule.Status.LastRunTime == nil || lastFinished.Status.StartTime.Time.After(rule.Status.LastRunTime.Time)) {
-				rule.Status.LastRunTime = lastFinished.Status.StartTime
-			}
+		if !didJobSucceed(lastFinished) && lastFinished.Status.StartTime != nil &&
+			(rule.Status.LastRunTime == nil || lastFinished.Status.StartTime.Time.After(rule.Status.LastRunTime.Time)) {
+			rule.Status.LastRunTime = lastFinished.Status.StartTime
 		}
 	}
 }
@@ -494,13 +530,8 @@ func (r *ArchiveRuleReconciler) setNotReady(
 	rule *aprv1alpha1.ArchiveRule,
 	reason, message string,
 ) (ctrl.Result, error) {
-	apimeta.SetStatusCondition(&rule.Status.Conditions, metav1.Condition{
-		Type:               ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: rule.Generation,
-	})
+	setCondition(&rule.Status.Conditions, ConditionReady, metav1.ConditionFalse,
+		reason, message, rule.Generation)
 	rule.Status.ObservedGeneration = rule.Generation
 	if err := r.Status().Update(ctx, rule); err != nil {
 		if apierrors.IsConflict(err) {
@@ -509,6 +540,20 @@ func (r *ArchiveRuleReconciler) setNotReady(
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 	return ctrl.Result{RequeueAfter: requeueWhileBusy}, nil
+}
+
+// setCondition is a thin wrapper over apimeta.SetStatusCondition that
+// keeps reconciler call sites short. ObservedGeneration is taken from the
+// caller-supplied generation so the condition reflects the spec the
+// reconciler actually saw.
+func setCondition(conds *[]metav1.Condition, condType string, status metav1.ConditionStatus, reason, message string, generation int64) {
+	apimeta.SetStatusCondition(conds, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: generation,
+	})
 }
 
 func triggerSource(manual, scheduled bool) string {

--- a/internal/controller/archiverule_controller_test.go
+++ b/internal/controller/archiverule_controller_test.go
@@ -73,6 +73,25 @@ func TestArchiveRule_InvalidSchedule(t *testing.T) {
 
 	got := getArchiveRule(t, ctx, ns, "rule1")
 	requireReady(t, got.Status.Conditions, metav1.ConditionFalse, ReasonInvalidSchedule)
+	requireCondition(t, got.Status.Conditions, ConditionScheduleValid, metav1.ConditionFalse, ReasonInvalidSchedule)
+}
+
+func TestArchiveRule_ValidScheduleSetsScheduleValidTrue(t *testing.T) {
+	requireEnvtest(t)
+	ctx := t.Context()
+	ns := mustCreateNamespace(t, ctx, "ar-good-sched")
+
+	mustCreate(t, ctx, newDatabaseConnection(ns, "dbc1"))
+	mustCreate(t, ctx, newStorageBackend(ns, "sb1"))
+	mustCreate(t, ctx, newArchiveRule(ns, "rule1", "dbc1", "sb1"))
+
+	r := newArchiveRuleReconciler()
+	if _, err := r.Reconcile(ctx, reqFor(ns, "rule1")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := getArchiveRule(t, ctx, ns, "rule1")
+	requireCondition(t, got.Status.Conditions, ConditionScheduleValid, metav1.ConditionTrue, ReasonScheduleParsed)
+	requireCondition(t, got.Status.Conditions, ConditionProgressing, metav1.ConditionFalse, ReasonJobIdle)
 }
 
 // --- Scheduling: do not fire before NextScheduledTime ---
@@ -344,9 +363,7 @@ func TestArchiveRule_FailedJobIncrementsFailures(t *testing.T) {
 	if got.Status.ConsecutiveFailures != 1 {
 		t.Errorf("ConsecutiveFailures = %d, want 1", got.Status.ConsecutiveFailures)
 	}
-	if got.Status.LastRunResult != aprv1alpha1.ArchiveRunFailed {
-		t.Errorf("LastRunResult = %q, want Failed (sink would not have run for crashed pod)", got.Status.LastRunResult)
-	}
+	requireCondition(t, got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue, ReasonLastRunFailed)
 }
 
 func TestArchiveRule_SuccessResetsFailureCount(t *testing.T) {
@@ -383,6 +400,33 @@ func TestArchiveRule_SuccessResetsFailureCount(t *testing.T) {
 	if got.Status.ConsecutiveFailures != 0 {
 		t.Errorf("ConsecutiveFailures = %d, want 0 (most recent Job succeeded)", got.Status.ConsecutiveFailures)
 	}
+	requireCondition(t, got.Status.Conditions, ConditionDegraded, metav1.ConditionFalse, ReasonLastRunSucceeded)
+}
+
+func TestArchiveRule_ProgressingWhenJobActive(t *testing.T) {
+	requireEnvtest(t)
+	ctx := t.Context()
+	ns := mustCreateNamespace(t, ctx, "ar-progressing")
+
+	mustCreate(t, ctx, newDatabaseConnection(ns, "dbc1"))
+	mustCreate(t, ctx, newStorageBackend(ns, "sb1"))
+	mustCreate(t, ctx, newArchiveRule(ns, "rule1", "dbc1", "sb1"))
+
+	r := newArchiveRuleReconciler()
+	if _, err := r.Reconcile(ctx, reqFor(ns, "rule1")); err != nil {
+		t.Fatal(err)
+	}
+	rule := getArchiveRule(t, ctx, ns, "rule1")
+
+	// An unfinished Job → reconciler must report Progressing=True.
+	active := newOwnedJob(t, "active-1", ns, rule)
+	mustCreate(t, ctx, active)
+
+	if _, err := r.Reconcile(ctx, reqFor(ns, "rule1")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := getArchiveRule(t, ctx, ns, "rule1")
+	requireCondition(t, got.Status.Conditions, ConditionProgressing, metav1.ConditionTrue, ReasonJobActive)
 }
 
 func TestArchiveRule_MaxFailuresAutoSuspends(t *testing.T) {
@@ -422,6 +466,7 @@ func TestArchiveRule_MaxFailuresAutoSuspends(t *testing.T) {
 	got := getArchiveRule(t, ctx, ns, "rule1")
 
 	requireReady(t, got.Status.Conditions, metav1.ConditionFalse, ReasonMaxFailuresReached)
+	requireCondition(t, got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue, ReasonMaxFailuresReached)
 	// No new Job should have been spawned (only the 2 failed ones).
 	if jobs := listJobs(t, ctx, ns); len(jobs) != 2 {
 		t.Errorf("expected exactly 2 Jobs (no new fire after auto-suspend), got %d", len(jobs))
@@ -745,12 +790,17 @@ func reqFor(ns, name string) ctrl.Request {
 
 func requireReady(t *testing.T, conds []metav1.Condition, status metav1.ConditionStatus, reason string) {
 	t.Helper()
-	cond := apimeta.FindStatusCondition(conds, ConditionReady)
+	requireCondition(t, conds, ConditionReady, status, reason)
+}
+
+func requireCondition(t *testing.T, conds []metav1.Condition, condType string, status metav1.ConditionStatus, reason string) {
+	t.Helper()
+	cond := apimeta.FindStatusCondition(conds, condType)
 	if cond == nil {
-		t.Fatalf("Ready condition not set")
+		t.Fatalf("%s condition not set; conds=%+v", condType, conds)
 	}
 	if cond.Status != status || cond.Reason != reason {
-		t.Fatalf("Ready condition = {Status:%s, Reason:%s}, want {Status:%s, Reason:%s}",
-			cond.Status, cond.Reason, status, reason)
+		t.Fatalf("%s condition = {Status:%s, Reason:%s}, want {Status:%s, Reason:%s}",
+			condType, cond.Status, cond.Reason, status, reason)
 	}
 }

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -57,21 +57,66 @@ const (
 // finished Job don't double-count.
 const AnnotationMetricsEmitted = "apr.dev/metrics-emitted"
 
-// Standard condition types and reasons used across reconcilers.
+// Standard condition types used across reconcilers. These follow the
+// Kubernetes API convention (metav1.Condition) so users can rely on
+// `kubectl wait --for=condition=...` and so generic tooling (ArgoCD, Flux)
+// can interpret resource health.
+//
+// Per-kind vocabulary:
+//
+//	DatabaseConnection / StorageBackend
+//	  Ready          credentials Secret exists with required keys
+//
+//	ArchiveRule
+//	  Ready          rule is configured correctly and not auto-suspended
+//	  ScheduleValid  spec.schedule is a parseable cron expression
+//	  Progressing    an archive Job is currently running
+//	  Degraded       most recent run failed (or consecutive failures > 0)
+//
+//	RestoreRequest
+//	  Ready          request is well-formed and references resolve
+//	  Progressing    Job is running
+//	  Succeeded      Job completed successfully (terminal)
+//	  Failed         Job failed terminally
 const (
-	ConditionReady = "Ready"
+	ConditionReady         = "Ready"
+	ConditionScheduleValid = "ScheduleValid"
+	ConditionProgressing   = "Progressing"
+	ConditionDegraded      = "Degraded"
+	ConditionSucceeded     = "Succeeded"
+	ConditionFailed        = "Failed"
+)
 
+// Standard reasons attached to the conditions above. Reasons are CamelCase
+// machine-readable tokens; the human-readable explanation goes in Message.
+const (
 	ReasonReady                      = "Ready"
 	ReasonDatabaseConnectionNotFound = "DatabaseConnectionNotFound"
 	ReasonStorageBackendNotFound     = "StorageBackendNotFound"
 	ReasonArchiveRuleNotFound        = "ArchiveRuleNotFound"
 	ReasonInvalidSchedule            = "InvalidSchedule"
+	ReasonScheduleParsed             = "ScheduleParsed"
 	ReasonJobReconcileError          = "JobReconcileError"
 	ReasonMaxFailuresReached         = "MaxFailuresReached"
 	ReasonSuspended                  = "Suspended"
 	ReasonSecretNotFound             = "SecretNotFound"
 	ReasonSecretMissingKeys          = "SecretMissingKeys"
 	ReasonNotImplemented             = "NotImplemented"
+
+	// Progressing reasons.
+	ReasonJobActive = "JobActive"
+	ReasonJobIdle   = "JobIdle"
+
+	// Degraded / outcome reasons.
+	ReasonLastRunSucceeded = "LastRunSucceeded"
+	ReasonLastRunFailed    = "LastRunFailed"
+	ReasonConsecutiveFails = "ConsecutiveFailures"
+
+	// RestoreRequest lifecycle reasons.
+	ReasonRestorePending   = "Pending"
+	ReasonRestoreRunning   = "Running"
+	ReasonRestoreSucceeded = "Succeeded"
+	ReasonRestoreFailed    = "Failed"
 )
 
 // Defaults applied to ArchiveRule.spec when the user leaves fields zero.

--- a/internal/controller/databaseconnection_controller.go
+++ b/internal/controller/databaseconnection_controller.go
@@ -141,23 +141,11 @@ func missingKeys(secret *corev1.Secret, keys ...string) []string {
 }
 
 func setReady(conds *[]metav1.Condition, gen int64, message string) {
-	apimeta.SetStatusCondition(conds, metav1.Condition{
-		Type:               ConditionReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             ReasonReady,
-		Message:            message,
-		ObservedGeneration: gen,
-	})
+	setCondition(conds, ConditionReady, metav1.ConditionTrue, ReasonReady, message, gen)
 }
 
 func setNotReady(conds *[]metav1.Condition, gen int64, reason, message string) {
-	apimeta.SetStatusCondition(conds, metav1.Condition{
-		Type:               ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: gen,
-	})
+	setCondition(conds, ConditionReady, metav1.ConditionFalse, reason, message, gen)
 }
 
 func isReady(conds []metav1.Condition) bool {

--- a/internal/controller/restorerequest_controller.go
+++ b/internal/controller/restorerequest_controller.go
@@ -10,7 +10,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,8 +23,10 @@ import (
 )
 
 // RestoreRequestReconciler implements one-shot restore execution: each RR
-// owns a Job that runs `apr restore --from-cr`. The Phase field on RR is
-// derived from observed Job state (Pending → Running → Succeeded/Failed).
+// owns a Job that runs `apr restore --from-cr`. Lifecycle is exposed via
+// the standard Conditions: Progressing flips True when the Job is active,
+// then Succeeded or Failed becomes True when the Job reaches a terminal
+// state.
 //
 // Spec is treated as immutable after the Job is created; to re-run a
 // restore, create a new RR. Detecting / rejecting spec mutation is left to
@@ -102,16 +103,12 @@ func (r *RestoreRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		logger.Error(err, "emitting restore metrics")
 	}
 
-	// Reflect Job state into Phase. The sink writes RowsRestored / times
-	// directly from inside the pod; we only manage Phase and JobRef here.
+	// Reflect Job state into Conditions. The sink writes RowsRestored /
+	// times directly from inside the pod; we only manage conditions and
+	// JobRef here.
 	r.applyJobStatus(&rr, job)
-	apimeta.SetStatusCondition(&rr.Status.Conditions, metav1.Condition{
-		Type:               ConditionReady,
-		Status:             metav1.ConditionTrue,
-		Reason:             ReasonReady,
-		Message:            "Job reconciled",
-		ObservedGeneration: rr.Generation,
-	})
+	setCondition(&rr.Status.Conditions, ConditionReady, metav1.ConditionTrue,
+		ReasonReady, "Job reconciled", rr.Generation)
 	rr.Status.ObservedGeneration = rr.Generation
 	if err := r.Status().Update(ctx, &rr); err != nil {
 		if apierrors.IsConflict(err) {
@@ -121,7 +118,7 @@ func (r *RestoreRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	logger.V(1).Info("reconciled RestoreRequest",
-		"job", job.Name, "phase", rr.Status.Phase)
+		"job", job.Name)
 	return ctrl.Result{}, nil
 }
 
@@ -198,24 +195,39 @@ func (r *RestoreRequestReconciler) desiredJobSpec(
 	}
 }
 
-// applyJobStatus derives the RestoreRequest.Phase from the Job's terminal
-// state. The Job pod itself writes RowsRestored / StartTime / CompletionTime
-// via cluster.RecordRestoreResult — those fields are not reflected here.
+// applyJobStatus derives the RestoreRequest's Progressing/Succeeded/Failed
+// conditions from the Job's terminal state. The Job pod itself writes
+// RowsRestored / StartTime / CompletionTime via cluster.RecordRestoreResult
+// — those fields are not reflected here.
+//
+// Conditions are set so that exactly one of Succeeded / Failed is True
+// after the Job terminates (and neither is True until then). Progressing
+// is True only while the Job is actively running.
 func (r *RestoreRequestReconciler) applyJobStatus(rr *aprv1alpha1.RestoreRequest, job *batchv1.Job) {
 	rr.Status.JobRef = &corev1.LocalObjectReference{Name: job.Name}
 
 	switch {
 	case job.Status.Succeeded > 0:
-		rr.Status.Phase = aprv1alpha1.RestoreSucceeded
+		setCondition(&rr.Status.Conditions, ConditionProgressing, metav1.ConditionFalse,
+			ReasonRestoreSucceeded, "restore Job completed successfully", rr.Generation)
+		setCondition(&rr.Status.Conditions, ConditionSucceeded, metav1.ConditionTrue,
+			ReasonRestoreSucceeded, "restore Job completed successfully", rr.Generation)
+		setCondition(&rr.Status.Conditions, ConditionFailed, metav1.ConditionFalse,
+			ReasonRestoreSucceeded, "restore Job completed successfully", rr.Generation)
 	case job.Status.Failed > 0 && jobIsTerminal(job):
 		// Backoff limit exhausted — sink may not have run.
-		rr.Status.Phase = aprv1alpha1.RestoreFailed
+		setCondition(&rr.Status.Conditions, ConditionProgressing, metav1.ConditionFalse,
+			ReasonRestoreFailed, "restore Job failed terminally", rr.Generation)
+		setCondition(&rr.Status.Conditions, ConditionSucceeded, metav1.ConditionFalse,
+			ReasonRestoreFailed, "restore Job failed terminally", rr.Generation)
+		setCondition(&rr.Status.Conditions, ConditionFailed, metav1.ConditionTrue,
+			ReasonRestoreFailed, "restore Job failed terminally", rr.Generation)
 	case job.Status.Active > 0:
-		rr.Status.Phase = aprv1alpha1.RestoreRunning
+		setCondition(&rr.Status.Conditions, ConditionProgressing, metav1.ConditionTrue,
+			ReasonRestoreRunning, fmt.Sprintf("restore Job %q is running", job.Name), rr.Generation)
 	default:
-		if rr.Status.Phase == "" {
-			rr.Status.Phase = aprv1alpha1.RestorePending
-		}
+		setCondition(&rr.Status.Conditions, ConditionProgressing, metav1.ConditionFalse,
+			ReasonRestorePending, "restore Job has not started yet", rr.Generation)
 	}
 }
 
@@ -236,14 +248,12 @@ func (r *RestoreRequestReconciler) markFailed(
 	rr *aprv1alpha1.RestoreRequest,
 	reason, message string,
 ) (ctrl.Result, error) {
-	rr.Status.Phase = aprv1alpha1.RestoreFailed
-	apimeta.SetStatusCondition(&rr.Status.Conditions, metav1.Condition{
-		Type:               ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: rr.Generation,
-	})
+	setCondition(&rr.Status.Conditions, ConditionReady, metav1.ConditionFalse,
+		reason, message, rr.Generation)
+	setCondition(&rr.Status.Conditions, ConditionFailed, metav1.ConditionTrue,
+		reason, message, rr.Generation)
+	setCondition(&rr.Status.Conditions, ConditionProgressing, metav1.ConditionFalse,
+		reason, message, rr.Generation)
 	rr.Status.ObservedGeneration = rr.Generation
 	if err := r.Status().Update(ctx, rr); err != nil {
 		if apierrors.IsConflict(err) {

--- a/internal/controller/restorerequest_controller_test.go
+++ b/internal/controller/restorerequest_controller_test.go
@@ -30,9 +30,7 @@ func TestRR_MissingArchiveRule(t *testing.T) {
 	}
 
 	got := getRR(t, ctx, ns, "rr1")
-	if got.Status.Phase != aprv1alpha1.RestoreFailed {
-		t.Errorf("Phase = %q, want Failed", got.Status.Phase)
-	}
+	requireCondition(t, got.Status.Conditions, ConditionFailed, metav1.ConditionTrue, ReasonArchiveRuleNotFound)
 	cond := apimeta.FindStatusCondition(got.Status.Conditions, ConditionReady)
 	if cond == nil || cond.Reason != ReasonArchiveRuleNotFound {
 		t.Errorf("expected Ready=False/%s, got %+v", ReasonArchiveRuleNotFound, cond)
@@ -58,8 +56,13 @@ func TestRR_HappyPathCreatesJob(t *testing.T) {
 	if got.Status.JobRef == nil {
 		t.Fatal("expected status.jobRef set after successful reconcile")
 	}
-	if got.Status.Phase != aprv1alpha1.RestorePending {
-		t.Errorf("Phase = %q, want Pending (Job hasn't started)", got.Status.Phase)
+	// Job hasn't started → Progressing=False/Pending; no terminal condition yet.
+	requireCondition(t, got.Status.Conditions, ConditionProgressing, metav1.ConditionFalse, ReasonRestorePending)
+	if c := apimeta.FindStatusCondition(got.Status.Conditions, ConditionSucceeded); c != nil && c.Status == metav1.ConditionTrue {
+		t.Errorf("Succeeded should not be True before Job runs: %+v", c)
+	}
+	if c := apimeta.FindStatusCondition(got.Status.Conditions, ConditionFailed); c != nil && c.Status == metav1.ConditionTrue {
+		t.Errorf("Failed should not be True before Job runs: %+v", c)
 	}
 
 	var job batchv1.Job
@@ -137,9 +140,9 @@ func TestRR_PhaseReflectsJobSuccess(t *testing.T) {
 		t.Fatalf("reconcile after Job success: %v", err)
 	}
 	got := getRR(t, ctx, ns, "rr1")
-	if got.Status.Phase != aprv1alpha1.RestoreSucceeded {
-		t.Errorf("Phase = %q, want Succeeded after Job.status.Succeeded > 0", got.Status.Phase)
-	}
+	requireCondition(t, got.Status.Conditions, ConditionSucceeded, metav1.ConditionTrue, ReasonRestoreSucceeded)
+	requireCondition(t, got.Status.Conditions, ConditionProgressing, metav1.ConditionFalse, ReasonRestoreSucceeded)
+	requireCondition(t, got.Status.Conditions, ConditionFailed, metav1.ConditionFalse, ReasonRestoreSucceeded)
 }
 
 // --- helpers ---

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -6,7 +6,10 @@ package controller
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"sync"
+	"syscall"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,38 +40,67 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("KUBEBUILDER_ASSETS") != "" {
-		utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
-		utilruntime.Must(aprv1alpha1.AddToScheme(testScheme))
+	// runTests is wrapped so `defer testEnv.Stop()` actually fires — `os.Exit`
+	// in TestMain skips deferred functions, so the previous form leaked the
+	// kube-apiserver/etcd children whenever m.Run() panicked. We also install
+	// a SIGINT/SIGTERM handler so `Ctrl+C` while `make test-envtest` is
+	// running cleans up rather than orphaning the subprocesses.
+	os.Exit(runTests(m))
+}
 
-		repoRoot, err := filepath.Abs("../..")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "envtest setup: %v\n", err)
-			os.Exit(1)
-		}
-		testEnv = &envtest.Environment{
-			CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd", "bases")},
-			ErrorIfCRDPathMissing: true,
-		}
-		cfg, err := testEnv.Start()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "envtest start: %v\n", err)
-			os.Exit(1)
-		}
-		testCfg = cfg
-		testClient, err = client.New(testCfg, client.Options{Scheme: testScheme})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "envtest client: %v\n", err)
-			os.Exit(1)
-		}
+func runTests(m *testing.M) int {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		return m.Run()
 	}
 
-	code := m.Run()
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(aprv1alpha1.AddToScheme(testScheme))
 
-	if testEnv != nil {
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest setup: %v\n", err)
+		return 1
+	}
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join(repoRoot, "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest start: %v\n", err)
+		return 1
+	}
+	testCfg = cfg
+	testClient, err = client.New(testCfg, client.Options{Scheme: testScheme})
+	if err != nil {
 		_ = testEnv.Stop()
+		fmt.Fprintf(os.Stderr, "envtest client: %v\n", err)
+		return 1
 	}
-	os.Exit(code)
+
+	// stopOnce guards against double-Stop from both the deferred path and
+	// the signal-handler path racing on Ctrl+C.
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			if err := testEnv.Stop(); err != nil {
+				fmt.Fprintf(os.Stderr, "envtest stop: %v\n", err)
+			}
+		})
+	}
+	defer stop()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		fmt.Fprintf(os.Stderr, "envtest: received %s, stopping control plane\n", s)
+		stop()
+		// 128 + signal number is the conventional shell exit code.
+		os.Exit(128 + int(s.(syscall.Signal)))
+	}()
+
+	return m.Run()
 }
 
 // requireEnvtest skips the test if the envtest control plane wasn't started.

--- a/internal/webhook/restorerequest_test.go
+++ b/internal/webhook/restorerequest_test.go
@@ -81,7 +81,7 @@ func TestRestoreRequestValidator_StatusOnlyUpdateAllowed(t *testing.T) {
 
 	old := newRR("ns1", "rr1", "rule1")
 	newer := old.DeepCopy()
-	newer.Status.Phase = aprv1alpha1.RestoreSucceeded
+	newer.Status.RowsRestored = 42
 
 	if _, err := v.ValidateUpdate(context.Background(), old, newer); err != nil {
 		t.Errorf("status-only update should be admitted, got %v", err)


### PR DESCRIPTION
## Summary

Closes #63. Migrates all four CRDs to expose lifecycle state via standard `metav1.Condition` arrays instead of ad-hoc enum fields, so `kubectl wait --for=condition=...` works and GitOps tooling (ArgoCD, Flux) can interpret resource health.

**Breaking change** (v1alpha1, no known external users): `ArchiveRule.status.lastRunResult` and `RestoreRequest.status.phase` are removed.

### Standard condition vocabulary

| Kind | Conditions |
|---|---|
| `DatabaseConnection`, `StorageBackend` | `Ready` |
| `ArchiveRule` | `Ready`, `ScheduleValid`, `Progressing`, `Degraded` |
| `RestoreRequest` | `Ready`, `Progressing`, `Succeeded`, `Failed` |

`Reachable` was deliberately deferred to #72 (requires real probing; `Unknown`-forever would be misleading).

### Notable design choices

- The cluster-side sink writes `Degraded` from inside the Job pod (fast user feedback). The reconciler also writes `Degraded` defensively for crashed pods that exit before the sink runs. Both use `apimeta.SetStatusCondition` (idempotent).
- Numeric/temporal fields (`lastRunRowsArchived`, `lastRunID`, `lastRunTime`, `rowsRestored`, etc.) stay as plain status fields — conditions are for state-machine signals, not denormalized data.
- Printer columns updated so `kubectl get archiverule` shows `READY/PROGRESSING/DEGRADED` and `kubectl get restorerequest` shows `PROGRESSING/SUCCEEDED/FAILED`.

### Bonus: envtest cleanup fix

`TestMain` previously leaked the `kube-apiserver` and `etcd` subprocesses on panic (because `os.Exit` skips deferred cleanup) and on `Ctrl+C` (no signal handler). Refactored to wrap the body in a `runTests()` function with `defer testEnv.Stop()`, plus a `SIGINT/SIGTERM` handler. `sync.Once` guards against the two paths racing.

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make test-envtest` — all reconciler tests pass; verified no orphaned `kube-apiserver`/`etcd` after the run completes
- [x] `make lint` — clean
- [x] `make helm-lint` — clean
- [x] `go vet -tags k8s ./integration/...` — clean
- [x] `make manifests generate helm-sync-crds` — committed (CRDs and chart in sync with API types)
- [x] Reviewer: spin up the kind e2e (`make test-k8s-clean`) to verify the integration suite passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)