### PR TITLE
ci: GoReleaser pipeline for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # create GitHub release + upload assets
+  packages: write   # push container image to ghcr.io
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for changelog generation
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          cache: true
+
+      # zig provides C/C++ toolchains for every (goos, goarch) we ship,
+      # which avoids juggling separate matrix runners for CGO targets.
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: "0.13.0"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,134 @@
+version: 2
+
+project_name: apr
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  # CLI: CGO is required (mattn/go-sqlite3 backs the `apr history` store).
+  # Cross-compiled with zig as the C compiler so a single ubuntu runner
+  # can produce linux/{amd64,arm64} and darwin/{amd64,arm64} binaries.
+  - id: apr
+    main: ./cmd/apr
+    binary: apr
+    env:
+      - CGO_ENABLED=1
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CC=zig cc -target x86_64-linux-musl
+          - CXX=zig c++ -target x86_64-linux-musl
+        ldflags:
+          - -s -w -X main.version={{ .Version }} -linkmode external -extldflags "-static"
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=zig cc -target aarch64-linux-musl
+          - CXX=zig c++ -target aarch64-linux-musl
+        ldflags:
+          - -s -w -X main.version={{ .Version }} -linkmode external -extldflags "-static"
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=zig cc -target x86_64-macos
+          - CXX=zig c++ -target x86_64-macos
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=zig cc -target aarch64-macos
+          - CXX=zig c++ -target aarch64-macos
+
+  # Operator: pure-Go (no SQLite import path), linux-only — it runs in
+  # the container image, never standalone.
+  - id: apr-manager
+    main: ./cmd/manager
+    binary: apr-manager
+    env:
+      - CGO_ENABLED=0
+    goos: [linux]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: apr-cli
+    ids: [apr]
+    name_template: "apr_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Performance
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - '^refactor:'
+      - '^style:'
+
+dockers_v2:
+  - id: image
+    images:
+      - "ghcr.io/carlos-loya/archive-purge-restore"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: Dockerfile.release
+    ids: [apr, apr-manager]
+    labels:
+      org.opencontainers.image.source: https://github.com/carlos-loya/archive-purge-restore
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: MIT
+
+release:
+  github:
+    owner: carlos-loya
+    name: archive-purge-restore
+  draft: false
+  prerelease: auto
+  header: |
+    ## APR {{ .Tag }}
+
+    Container image:
+    ```
+    docker pull ghcr.io/carlos-loya/archive-purge-restore:{{ .Version }}
+    ```
+
+    Helm chart (set `image.tag` to `{{ .Version }}`):
+    ```
+    helm install apr ./charts/apr --set image.tag={{ .Version }}
+    ```

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,15 @@
+# Release image. GoReleaser builds the binaries on the host (CGO via zig)
+# and supplies them in the build context — this Dockerfile only assembles
+# the runtime layer. For local/dev builds, see ./Dockerfile.
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata && \
+    addgroup -S apr -g 65532 && \
+    adduser -S apr -G apr -u 65532
+
+COPY apr /apr
+COPY apr-manager /apr-manager
+
+USER 65532:65532
+
+ENTRYPOINT ["/apr"]

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,15 @@ IMG ?= ghcr.io/carlos-loya/archive-purge-restore:dev
 docker-build:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMG) .
 
+# release-snapshot exercises the GoReleaser pipeline locally without
+# publishing anything. Requires goreleaser + zig (for CGO cross-compile).
+# Artifacts land in ./dist/.
+release-snapshot:
+	goreleaser release --snapshot --clean --skip=publish
+
+release-check:
+	goreleaser check
+
 # helm-sync-crds copies the controller-gen-generated CRDs into the Helm
 # chart's crds/ directory. Run this any time the CRD types change.
 helm-sync-crds: manifests


### PR DESCRIPTION
## Summary
- Adds `.goreleaser.yaml` + `.github/workflows/release.yml` that fire on `v*` tag push.
- Produces CLI tarballs for linux/{amd64,arm64} and darwin/{amd64,arm64}. CGO is required (`mattn/go-sqlite3`); `zig-cc` is used as the cross-compiler so a single ubuntu runner covers all four targets. Linux builds are static musl so the same artifact works on glibc and alpine hosts.
- Publishes a multi-arch (linux/amd64+arm64) image at `ghcr.io/carlos-loya/archive-purge-restore` via `dockers_v2` + buildx. Both `/apr` and `/apr-manager` land in the image, matching what the Helm chart expects.
- `Dockerfile.release` is a thin runtime layer over alpine:3.21 that consumes the prebuilt binaries from GoReleaser; the existing `Dockerfile` is untouched for local/dev workflows.
- Adds `make release-snapshot` / `make release-check` for local exercising.

Closes #57. Closes #58.

## Test plan
- [x] `make release-check` passes (validated locally with `goreleaser check`).
- [ ] On the first `v*` tag, the `Release` workflow runs to completion.
- [ ] GitHub release lists tarballs for all four CLI platforms + `checksums.txt`.
- [ ] `docker pull ghcr.io/carlos-loya/archive-purge-restore:<tag>` works on amd64 and arm64.
- [ ] `helm install apr ./charts/apr --set image.tag=<tag>` boots the manager on a kind cluster.

## Notes
- zig-cc was picked over native-matrix builds because it avoids GoReleaser Pro's `--split` requirement and keeps the release pipeline a single job; macOS targeting also works since SQLite needs only libc, not Frameworks.
- The first tagged release will be the smoke test for this — recommend cutting `v0.3.0-rc1` or similar to validate before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)